### PR TITLE
Check for ggplot2 version

### DIFF
--- a/server.R
+++ b/server.R
@@ -4,6 +4,22 @@
 # p_load(shiny,shinyBS,ggplot2,reshape2,plyr,dplyr,tidyr,scales,grid,gridExtra,ape,stringr,gtable,dendextend,ggdendro,gplots,data.table,taxize,rdrop2,install=T)
 #######################################################
 
+version_above <- function(pkg, than) {
+  compareVersion(as.character(packageVersion(pkg)), than)
+}
+
+if ("ggplot2" %in% rownames(installed.packages())) {
+  if (version_above("ggplot2","2.2.0") == -1) {
+    source("https://bioconductor.org/biocLite.R")
+    biocLite("ggplot2")
+    require("ggplot2")
+  }
+} else {
+  source("https://bioconductor.org/biocLite.R")
+  biocLite("ggplot2")
+  require("ggplot2")
+}
+
 if (!require("shiny")) {install.packages("shiny")}
 if (!require("shinyBS")) {install.packages("shinyBS")}
 if (!require("ggplot2")) {install.packages("ggplot2")}


### PR DESCRIPTION
This is just an example for `ggplot2` now, but it does two things: 

1. it checks whether `ggplot2` is installed, if that's not the case it uses `biocLite` to install the latest version. 
2. if `ggplot2` is indeed installed, it checks whether the version is < `2.2.0`. If that's the case it will reinstall `ggplot2` to get the latest version, to avoid #14. 

The benefit of doing it like this: Even if no `ggplot2` is installed it will not crash with a `CRAN mirror not specified` error as `biocLite` doesn't care for those. 